### PR TITLE
upgrade component versions

### DIFF
--- a/chapter01_cluster-create/helm/helmfile.yaml
+++ b/chapter01_cluster-create/helm/helmfile.yaml
@@ -17,13 +17,13 @@ releases:
   namespace: metallb-system
   createNamespace: true
   chart: metallb/metallb
-  version: 0.13.12
+  version: 0.14.5
   values:
   - values/metallb.values.yaml
 - name: ingress-nginx
   namespace: ingress-nginx
   createNamespace: true
   chart: ingress-nginx/ingress-nginx
-  version: 4.8.0
+  version: 4.10.1
   values:
   - values/ingress-nginx.values.yaml

--- a/chapter02_prometheus/helm/helmfile.yaml
+++ b/chapter02_prometheus/helm/helmfile.yaml
@@ -7,6 +7,6 @@ releases:
   namespace: prometheus
   createNamespace: true
   chart: prometheus-community/kube-prometheus-stack
-  version: 50.3.1
+  version: 58.3.3
   values:
   - prometheus-values.yaml

--- a/chapter05_argocd/helm/helmfile.yaml
+++ b/chapter05_argocd/helm/helmfile.yaml
@@ -6,6 +6,6 @@ releases:
 - name: argo-cd
   namespace: argo-cd
   chart: argo/argo-cd
-  version: 5.35.0
+  version: 6.7.18
   values:
   - values.yaml

--- a/chapter08_argo-rollouts/helm/helmfile.yaml
+++ b/chapter08_argo-rollouts/helm/helmfile.yaml
@@ -6,6 +6,6 @@ releases:
 - name: argo-rollouts
   namespace: argo-rollouts
   chart: argo/argo-rollouts
-  version: 2.14.0
+  version: 2.35.2
   values:
   - values.yaml


### PR DESCRIPTION
hubbleはciliumに内包されている形なのでアップグレードせず。ciliumは最新バージョンに変更なし。
アップグレードするのは下記のコンポーネント。アップグレード後に動作確認済み。
* Prometheus / Grafana
* Argo CD
* Argo Rollouts
* Ingress Nginx
* MetalLB

close: https://github.com/cloudnativedaysjp/cnd-handson/issues/263