### PR TITLE
Chapter Istio/Istio Ambient Mesh: README.mdの修正。

### DIFF
--- a/chapter_istio-ambientmesh/README.md
+++ b/chapter_istio-ambientmesh/README.md
@@ -19,8 +19,9 @@
 
 Istio ambient meshはこれらの問題を解決する目的で、Google, Solo.ioによって開発が始まりました。
 
-> [!IMPORTANT]
->  Istio ambient meshは2023年11月末時点ではαステータスです。本番環境への導入は控え、検証用途でのみ使用してください。
+> [!NOTE]
+> Istio ambient meshは、2024年5月、v1.22にてbetaバージョンとなっています。
+> https://istio.io/latest/news/releases/1.22.x/announcing-1.22/
 
 ### Istio ambient mesh構成
 L4、L7機能の全てを管理しているサイドカーモードにおけるデータプレーンと異なり、Istio ambientモードではデータプレーンの機能を2つの層に分けて管理をします。
@@ -638,14 +639,10 @@ kubectl delete -f app/curl.yaml
 ```
 
 ## まとめ
-サイドカーを用いないIstioの新しいデータプレーンであるIstio ambient meshを使用することで、アプリケーションと、データプレーンの分離が可能になります。これにより、データプレーン起因によるアプリケーションワークロードの阻害を防止することができます。さらに、サイドカーを使用せずに、ztunnel, waypoint proxyを用いることにより、L4, L7管理をアプリケーションの必要に応じて実装することができるようになります。2023年11月の段階ではalphaステータスでありますが、Istio ambient meshをぜひ試してみてください。
+サイドカーを用いないIstioの新しいデータプレーンであるIstio ambient meshを使用することで、アプリケーションと、データプレーンの分離が可能になります。これにより、データプレーン起因によるアプリケーションワークロードの阻害を防止することができます。さらに、サイドカーを使用せずに、ztunnel, waypoint proxyを用いることにより、L4, L7管理をアプリケーションの必要に応じて実装することができるようになります。
 
 Istio ambient meshに関するGitHub Issue: https://github.com/istio/istio/labels/area%2Fambient
 
-> [!NOTE]
->
-> Istio ambient meshは、2024年5月、v1.22にてbetaになりました。
-> https://istio.io/latest/news/releases/1.22.x/announcing-1.22/
 
 ## 最終クリーンアップ
 本chapter用に作成したKubernetes clusterを削除します。

--- a/chapter_istio/README.md
+++ b/chapter_istio/README.md
@@ -336,19 +336,19 @@ Kialiでトラフィックを確認すると、`handson-blue` トラフィック
 最後に、ヘッダーを何もつけない場合どのようになるのか確認してみましょう。
 
 ```sh
-while :; do curl -s -w '%header{location}\t%{http_code}\n' http://app.example.com:18080/color ;sleep 1;done
+while :; do curl -s -w '%{http_code}\n' http://app.example.com:18080/color ;sleep 1;done
 ```
 
 コンソールには下記のように表示されるはずです。
 
 ```sh
-http://app.example.com/maintenance.html 302
-http://app.example.com/maintenance.html 302
-http://app.example.com/maintenance.html 302
+302
+302
+302
 ```
 
 Kialiでトラフィックを確認すると、workload側にはトラフィックが流れていないことがわかります。<br>
-**[HTTPRedirect](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRedirect)を使う際は、デフォルトのHTTPレスポンスコードが301(MOVED_PERMANENTLY)であることに注意してください。**利用シーンとして一時的にトラフィックを別の場所にリダイレクトさせたい場合は、302(Found)などを使うようにしましょう。301を使う場合は、ブラウザ側がそのリダイレクト情報をキャッシュしてしまいます。
+[HTTPRedirect](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRedirect)を使う際は、デフォルトのHTTPレスポンスコードが301(MOVED_PERMANENTLY)であることに注意してください。利用シーンとして一時的にトラフィックを別の場所にリダイレクトさせたい場合は、302(Found)などを使うようにしましょう。301を使う場合は、ブラウザ側がそのリダイレクト情報をキャッシュしてしまいます。
 
 ![image](./image/kiali-graph-http-request-based-routing-redirect.png)
 


### PR DESCRIPTION
### Summary

- [x] 太字が正しく表示されていない問題の修正。
- [x] curl v7.81では、 `%header` syntaxが使えない問題の修正。
- [x] Istio Ambient Meshのバージョン情報に対する注意事項記載箇所の変更


### References

curlについて。 `%header`は、7.84で追加された。
https://curl.se/docs/manpage.html

> Output HTTP headers from the most recent request by using %header{name} where name is the case insensitive name of the header (without the trailing colon). The header contents are exactly as sent over the network, with leading and trailing whitespace trimmed (added in 7.84.0). 