### PR TITLE
rollouts-extensionのインストール方法を更新

### DIFF
--- a/chapter_argo-rollouts/README.md
+++ b/chapter_argo-rollouts/README.md
@@ -47,9 +47,26 @@ Argo CDとの連携が可能で、簡単に既存のGit Opsでプログレッシ
 [chapter_argocd](../chapter_argocd/README.md#argo-cdのインストール)を参照してArgo CDのインストールからWebUIの確認とレポジトリのforkから登録まで行って下さい。
 
 今回のchapterでは更にArgo CDのプラグインである、rollout-extensionをインストールしてArgoCD上でrolloutの操作結果が確認できるようにします。
+chapter_argocd/helmfile/values.yamlの更新をします。
+```values.yaml
+## Argo Configs
+configs:
+  params:
+  # -- Run server without TLS
+    server.insecure: true
+# ~~~~ ここから下を追記or更新 ~~~~
+server:
+  extensions:
+    enabled: true
+    extensionList:
+      - name: rollout-extension
+        env:
+          - name: EXTENSION_URL
+            value: https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.4/extension.tar
+```
+helmファイルの更新を行います。
 ```sh
-kubectl apply -n argo-cd \
-    -f https://raw.githubusercontent.com/argoproj-labs/rollout-extension/v0.2.1/manifests/install.yaml
+helmfile sync -f ./helm/helmfile.yaml
 ```
 
 


### PR DESCRIPTION
[argocd-extensionsの廃止](https://github.com/argoproj-labs/argocd-extensions?tab=readme-ov-file)に伴い、rollouts-extensionのインストール方法も更新されたのでReadmeの更新も行います。

**過去（非推奨）**
Argo CD 拡張機能を実行時に Argo CD API サーバーのReactによって動的にロードしている。
https://argo-cd.readthedocs.io/en/latest/proposals/002-ui-extensions/#argocdextension-crd


**現在**
argocd-api-serverの起動時にinitコンテナとしてArgo CD Extension Installerを起動させて、argocd-api-serverの/tmp/extensionsに保存させている。
https://argo-cd.readthedocs.io/en/latest/developer-guide/extensions/ui-extensions/