### PR TITLE
Gateway APIのインストール方法の変更

### DIFF
--- a/chapter_cluster-create/README.md
+++ b/chapter_cluster-create/README.md
@@ -118,6 +118,7 @@ Ingress NGINX Controllerはインターネットからkind上のServiceリソー
 
 ```shell
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/experimental-install.yaml
 ```
 
 Gateway API以外のコンポーネントはhelmfileコマンドを利用することでデプロイできます。

--- a/chapter_cluster-create/README.md
+++ b/chapter_cluster-create/README.md
@@ -117,12 +117,7 @@ Ingress NGINX Controllerはインターネットからkind上のServiceリソー
 まず、最初にGateway APIのCRDをデプロイします。
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml
 ```
 
 Gateway API以外のコンポーネントはhelmfileコマンドを利用することでデプロイできます。


### PR DESCRIPTION
## Summary

- Gateway APIのインストール方法をドキュメント記載の方法に変えました
  - see: https://gateway-api.sigs.k8s.io/guides/#install-standard-channe

## Review

- [ ] ぱっとみよさそう
- [ ] TLSRouteをこのリポジトリ内で利用していなそう