### PR TITLE
update hubble version and fix readme

### DIFF
--- a/chapter_hubble/README.md
+++ b/chapter_hubble/README.md
@@ -11,7 +11,7 @@ HubbleはCiliumのために開発されたネットワークとセキュリテ�
 
 ![](image/ch05_hubble-components_01.png)
 
-（出典：https://isovalent.com/blog/post/hubble-series-re-introducing-hubble/）
+（ 出典：https://isovalent.com/blog/post/hubble-series-re-introducing-hubble/ ）
 
 - Hubble Server
   - 各NodeのCilium Agentに組み込まれており、Prometheusメトリクスやネットワークおよびアプリケーションプロトコルレベルでのフロー情報の可視性を提供します

--- a/chapter_hubble/install-tools.sh
+++ b/chapter_hubble/install-tools.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-HUBBLE_VERSION=v0.12.0
+HUBBLE_VERSION=v1.16.1
 
 # Install hubble CLI
 # See: https://docs.cilium.io/en/stable/gettingstarted/hubble_setup/#install-the-hubble-client


### PR DESCRIPTION
- hubbleのバージョンをあげても挙動に変わりがないことを確認。それに伴いバージョンアップ
- hubbleのドキュメントにて、URLと括弧間にスペースをあけないとリンクにとべなかったので、スペース追加