### PR TITLE
temporarily disable renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,3 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "enabled": false
 }


### PR DESCRIPTION
動作確認完了したバージョンで固定するためHelm chartなどのアップデートPRを自動作成しないようRenovateを一時的に無効化します。