### PR TITLE
grafana update image for vulnerability

### DIFF
--- a/chapter_prometheus/helm/prometheus-values.yaml
+++ b/chapter_prometheus/helm/prometheus-values.yaml
@@ -1,4 +1,8 @@
 grafana:
+  image:
+    # 脆弱性報告により、Grafanaだけバージョン変更
+    # cf.) https://grafana.com/security/security-advisories/cve-2024-9264/
+    tag: 11.2.2-security-01
   adminUser: admin
   adminPassword: handson_saiko!
   dashboardProviders:


### PR DESCRIPTION
脆弱性報告により、Grafanaだけバージョン変更(11.2.0 -> 11.2.2-security-01)
cf.) https://grafana.com/security/security-advisories/cve-2024-9264/

2024/12/21 ハンズオンリハで動作上影響ないことを確認済み